### PR TITLE
Add support for interactive InfoWindows in clusters

### DIFF
--- a/InteractiveInfoWindowAndroid/interactive-info-window/src/main/java/com/appolica/interactiveinfowindow/InfoWindow.java
+++ b/InteractiveInfoWindowAndroid/interactive-info-window/src/main/java/com/appolica/interactiveinfowindow/InfoWindow.java
@@ -16,6 +16,7 @@ package com.appolica.interactiveinfowindow;
 
 import android.support.v4.app.Fragment;
 
+import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.Marker;
 
 import java.io.Serializable;
@@ -26,7 +27,7 @@ import java.io.Serializable;
  * or is in the middle of showing/hiding.
  */
 public class InfoWindow {
-    private Marker marker;
+    private LatLng position;
     private MarkerSpecification markerSpec;
 
     private Fragment windowFragment;
@@ -43,17 +44,23 @@ public class InfoWindow {
             MarkerSpecification markerSpec,
             Fragment windowFragment) {
 
-        this.marker = marker;
+        this(marker.getPosition(), markerSpec, windowFragment);
+    }
+
+    public InfoWindow(
+            LatLng position,
+            MarkerSpecification markerSpec,
+            Fragment windowFragment) {
+
+        this.position = position;
         this.markerSpec = markerSpec;
         this.windowFragment = windowFragment;
     }
 
-    public Marker getMarker() {
-        return marker;
-    }
+    public LatLng getPosition() { return position; }
 
-    public void setMarker(Marker marker) {
-        this.marker = marker;
+    public void setPosition(LatLng position) {
+        this.position = position;
     }
 
     public MarkerSpecification getMarkerSpec() {
@@ -140,7 +147,7 @@ public class InfoWindow {
     public boolean equals(Object o) {
 
         if (o instanceof InfoWindow) {
-            final boolean markerCheck = ((InfoWindow) o).getMarker().getPosition().equals(marker.getPosition());
+            final boolean markerCheck = ((InfoWindow) o).getPosition().equals(position);
             final boolean specCheck = ((InfoWindow) o).getMarkerSpec().equals(markerSpec);
 
             return markerCheck && specCheck;

--- a/InteractiveInfoWindowAndroid/interactive-info-window/src/main/java/com/appolica/interactiveinfowindow/InfoWindowManager.java
+++ b/InteractiveInfoWindowAndroid/interactive-info-window/src/main/java/com/appolica/interactiveinfowindow/InfoWindowManager.java
@@ -486,7 +486,7 @@ public class InfoWindowManager
 
     private void centerInfoWindow(@NonNull final InfoWindow infoWindow) {
         final Projection projection = googleMap.getProjection();
-        final Point screenLocation = projection.toScreenLocation(infoWindow.getMarker().getPosition());
+        final Point screenLocation = projection.toScreenLocation(infoWindow.getPosition());
 
         final int containerWidth = currentWindowContainer.getWidth();
         final int containerHeight = currentWindowContainer.getHeight();


### PR DESCRIPTION
This changes the InfoWindow to use `LatLng` instead of `Marker` in order to make it interactive InfoWindows possible for markers that are managed by a ClusterManager (https://developers.google.com/maps/documentation/android-api/utility/marker-clustering). 

With a cluster manager, not all markers are instantiated at the same time and so the markers cannot be passed to the InfoWindow. However, the InfoWindow only uses the marker's position, so we can generalise the InfoWindow implementation and use the position directly.

