### PR TITLE
Fixed issue 35 on main repo by setting state of the InfoWindow in propagateShowEvent

### DIFF
--- a/InteractiveInfoWindowAndroid/interactive-info-window/src/main/java/com/appolica/interactiveinfowindow/InfoWindowManager.java
+++ b/InteractiveInfoWindowAndroid/interactive-info-window/src/main/java/com/appolica/interactiveinfowindow/InfoWindowManager.java
@@ -451,6 +451,8 @@ public class InfoWindowManager
             @NonNull final InfoWindow infoWindow,
             @NonNull final InfoWindow.State state) {
 
+        infoWindow.setWindowState(state);
+
         if (windowShowListener != null) {
             switch (state) {
                 case SHOWING:


### PR DESCRIPTION
I'm not sure why this doesn't already exist. What's the point of keeping state in the `InfoWindow` if it doesn't get updated? There should be no reason for a library user to have to do:
```
final InfoWindowManager infoWindowManager = new InfoWindowManager(getFragmentManager());
infoWindowManager.setWindowShowListener(new InfoWindowManager.WindowShowListener() {
            @Override
            public void onWindowShowStarted(@NonNull InfoWindow infoWindow) {
                infoWindow.setWindowState(InfoWindow.State.SHOWING);
            }

            @Override
            public void onWindowShown(@NonNull InfoWindow infoWindow) {
                infoWindow.setWindowState(InfoWindow.State.SHOWN);
            }

            @Override
            public void onWindowHideStarted(@NonNull InfoWindow infoWindow) {
                infoWindow.setWindowState(InfoWindow.State.HIDING);
            }

            @Override
            public void onWindowHidden(@NonNull InfoWindow infoWindow) {
                infoWindow.setWindowState(InfoWindow.State.HIDDEN);
            }
        });
```
just to get the state updated.

**NOTE:** this only makes the change for _animated_ show and all hides. Non-animated show (the `else` in `internalShow`) does not call `propagateShowEvent`, therefore the state does not get changed and the listener does not fire. This should be handled in a separate issue.